### PR TITLE
feat: implement sharing functionality for whiteboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,207 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Whiteboard Canvas App
 
-## Getting Started
+A collaborative whiteboard drawing application built with Next.js 15, featuring real-time drawing capabilities, draft/publish workflow, and collaborative commenting system.
 
-First, run the development server:
+## ✨ Features
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- **Interactive Drawing Canvas**: Create drawings with various tools and colors
+- **Draft & Publish System**: Save drawings as drafts or publish them for sharing
+- **Collaborative Sharing**: Share published drawings with other users
+- **Real-time Comments**: Add and view multiple comments on whiteboards
+- **User Authentication**: Secure authentication with Clerk
+- **Responsive Design**: Works seamlessly across desktop and mobile devices
+
+## 🛠️ Tech Stack
+
+- **Framework**: [Next.js 15](https://nextjs.org/) with App Router
+- **Language**: [TypeScript](https://www.typescriptlang.org/)
+- **Styling**: [Tailwind CSS](https://tailwindcss.com/)
+- **Authentication**: [Clerk](https://clerk.com/)
+- **Database**: [Neon PostgreSQL](https://neon.tech/) (Serverless)
+- **ORM**: [Prisma](https://www.prisma.io/)
+
+## 🚀 Getting Started
+
+### Prerequisites
+
+- Node.js 18+ 
+- npm, yarn, or pnpm
+- A Clerk account for authentication
+- A Neon PostgreSQL database
+
+### Installation
+
+1. **Clone the repository**
+   ```bash
+   git clone <your-repo-url>
+   cd whiteboard-canvas-app
+   ```
+
+2. **Install dependencies**
+   ```bash
+   npm install
+   # or
+   yarn install
+   # or
+   pnpm install
+   ```
+
+3. **Set up environment variables**
+   
+   Create a `.env.local` file in the root directory and add the following variables:
+
+   ```env
+   # Clerk Authentication
+   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key
+   CLERK_SECRET_KEY=your_clerk_secret_key
+   CLERK_WEBHOOK_SECRET=your_clerk_webhook_secret
+
+   # Database
+   DATABASE_URL=your_neon_database_url
+
+   # Next.js
+   NEXTAUTH_URL=http://localhost:3000
+
+   # Clerk Redirects
+   NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/whiteboards
+   NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/whiteboards
+   NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/whiteboards
+   NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/whiteboards
+   ```
+
+4. **Set up the database**
+   ```bash
+   npx prisma generate
+   npx prisma db push
+   ```
+
+5. **Run the development server**
+   ```bash
+   npm run dev
+   # or
+   yarn dev
+   # or
+   pnpm dev
+   ```
+
+6. **Open your browser**
+   
+   Navigate to [http://localhost:3000](http://localhost:3000) to see the application.
+
+## 🗂️ Project Structure
+
+```
+├── app/                    # Next.js 15 App Router
+│   ├── (auth)/            # Authentication routes
+│   ├── whiteboards/       # Whiteboard pages
+│   ├── globals.css        # Global styles
+│   └── layout.tsx         # Root layout
+├── components/            # Reusable React components
+│   ├── ui/               # UI components
+│   └── whiteboard/       # Whiteboard-specific components
+├── lib/                   # Utility functions and configurations
+│   ├── prisma.ts         # Prisma client setup
+│   └── utils.ts          # Helper utilities
+├── prisma/               # Database schema and migrations
+│   └── schema.prisma     # Prisma schema
+├── public/               # Static assets
+└── types/                # TypeScript type definitions
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## 🎨 Key Features Explained
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Drawing Canvas
+- Interactive HTML5 Canvas for drawing
+- Multiple drawing tools (pen, eraser, shapes)
+- Color picker and brush size options
+- Undo/Redo functionality
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### Draft & Publish System
+- **Drafts**: Private drawings visible only to the creator
+- **Published**: Public drawings that can be shared with others
+- Easy toggle between draft and published states
 
-## Learn More
+### Collaborative Comments
+- Add comments to specific areas of the whiteboard
+- Real-time comment updates
+- User avatars and timestamps
+- Reply to existing comments
 
-To learn more about Next.js, take a look at the following resources:
+### Authentication & Authorization
+- Secure user authentication with Clerk
+- Protected routes for authenticated users
+- User profile management
+- Session handling
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## 🔧 Configuration
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+### Clerk Setup
+1. Create a Clerk application at [clerk.com](https://clerk.com)
+2. Copy your publishable key and secret key
+3. Configure redirect URLs in your Clerk dashboard
+4. Set up webhooks for user synchronization
 
-## Deploy on Vercel
+### Database Setup
+1. Create a Neon PostgreSQL database
+2. Copy the connection string
+3. Configure Prisma schema as needed
+4. Run migrations
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## 📱 API Routes
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `POST /api/whiteboards` - Create a new whiteboard
+- `GET /api/whiteboards` - Get user's whiteboards
+- `PUT /api/whiteboards/[id]` - Update whiteboard
+- `DELETE /api/whiteboards/[id]` - Delete whiteboard
+- `POST /api/comments` - Add comment to whiteboard
+- `GET /api/comments/[whiteboardId]` - Get whiteboard comments
+
+## 🚀 Deployment
+
+### Vercel (Recommended)
+
+1. **Deploy to Vercel**
+   ```bash
+   npm i -g vercel
+   vercel
+   ```
+
+2. **Configure Environment Variables**
+   - Add all environment variables in Vercel dashboard
+   - Ensure production URLs are updated
+
+3. **Update Clerk Configuration**
+   - Update redirect URLs to use your production domain
+   - Update webhook endpoints
+
+### Other Platforms
+
+The application can be deployed to any platform that supports Next.js:
+- Netlify
+- Railway
+- DigitalOcean App Platform
+- AWS Amplify
+
+
+## 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgments
+
+- Next.js team for the amazing framework
+- Clerk for seamless authentication
+- Neon for serverless PostgreSQL
+- Prisma for the excellent ORM
+- Tailwind CSS for styling utilities
+
+## 📞 Support
+
+If you have any questions or need help with setup, please:
+- Open an issue on GitHub
+- Check the [documentation](docs/)
+- Contact the maintainers
+
+---
+
+**Happy Drawing! 🎨**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@clerk/nextjs": "^6.31.0",
         "@prisma/client": "^6.14.0",
         "date-fns": "^4.1.0",
+        "nanoid": "^5.1.5",
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4148,9 +4149,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -4159,10 +4160,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/next": {
@@ -4215,6 +4216,24 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -4344,6 +4363,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prisma": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@clerk/nextjs": "^6.31.0",
     "@prisma/client": "^6.14.0",
     "date-fns": "^4.1.0",
+    "nanoid": "^5.1.5",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,8 +37,31 @@ model Whiteboard {
   isPubliclyShared Boolean @default(false)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  comments         Comment[]
 
   @@map("whiteboards")
+}
+
+model Comment {
+  id           String     @id @default(cuid())
+  whiteboardId String
+  userId       String     // Clerk user ID
+  userName     String     // User's display name
+  userEmail    String?    // User's email (optional)
+  userAvatar   String?    // User's avatar URL (optional)
+  text         String     // Comment text
+  x            Float      // X position on canvas
+  y            Float      // Y position on canvas
+  resolved     Boolean    @default(false)
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+  
+  // Relationship
+  whiteboard   Whiteboard @relation(fields: [whiteboardId], references: [id], onDelete: Cascade)
+  
+  @@map("comments")
+  @@index([whiteboardId])
+  @@index([whiteboardId, resolved])
 }
 
 enum WhiteboardStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model Whiteboard {
   status      WhiteboardStatus @default(DRAFT)
   content     Json?    // TLDraw snapshot data
   userId      String   // Clerk user ID
+  shareId     String?  @unique
+  isPubliclyShared Boolean @default(false)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/src/app/shared/[shareId]/page.tsx
+++ b/src/app/shared/[shareId]/page.tsx
@@ -1,0 +1,43 @@
+// src/app/shared/[shareId]/page.tsx
+import { notFound } from 'next/navigation'
+import { getSharedWhiteboard } from '@/lib/actions/sharing'
+import { SharedWhiteboardViewer } from '@/components/whiteboard/shared-whiteboard-viewer'
+
+interface SharedWhiteboardPageProps {
+    params: Promise<{ shareId: string }>
+}
+
+export default async function SharedWhiteboardPage({
+    params,
+}: SharedWhiteboardPageProps) {
+    const { shareId } = await params
+    const result = await getSharedWhiteboard(shareId)
+
+    if (!result.success || !result.data) {
+        notFound()
+    }
+
+    return (
+        <div className="h-screen flex flex-col">
+            <SharedWhiteboardViewer whiteboard={result.data} />
+        </div>
+    )
+}
+
+export async function generateMetadata({
+    params,
+}: SharedWhiteboardPageProps) {
+    const { shareId } = await params
+    const result = await getSharedWhiteboard(shareId)
+
+    if (!result.success || !result.data) {
+        return {
+            title: 'Whiteboard Not Found',
+        }
+    }
+
+    return {
+        title: `${result.data.name} - Shared Whiteboard`,
+        description: `View ${result.data.name} - a shared whiteboard`,
+    }
+}

--- a/src/app/shared/[shareId]/page.tsx
+++ b/src/app/shared/[shareId]/page.tsx
@@ -4,40 +4,40 @@ import { getSharedWhiteboard } from '@/lib/actions/sharing'
 import { SharedWhiteboardViewer } from '@/components/whiteboard/shared-whiteboard-viewer'
 
 interface SharedWhiteboardPageProps {
-    params: Promise<{ shareId: string }>
+  params: Promise<{ shareId: string }>
 }
 
 export default async function SharedWhiteboardPage({
-    params,
+  params,
 }: SharedWhiteboardPageProps) {
-    const { shareId } = await params
-    const result = await getSharedWhiteboard(shareId)
+  const { shareId } = await params
+  const result = await getSharedWhiteboard(shareId)
 
-    if (!result.success || !result.data) {
-        notFound()
-    }
+  if (!result.success || !result.data) {
+    notFound()
+  }
 
-    return (
-        <div className="h-screen flex flex-col">
-            <SharedWhiteboardViewer whiteboard={result.data} />
-        </div>
-    )
+  return (
+    <div className="h-screen flex flex-col">
+      <SharedWhiteboardViewer whiteboard={result.data} shareId={shareId} />
+    </div>
+  )
 }
 
 export async function generateMetadata({
-    params,
+  params,
 }: SharedWhiteboardPageProps) {
-    const { shareId } = await params
-    const result = await getSharedWhiteboard(shareId)
+  const { shareId } = await params
+  const result = await getSharedWhiteboard(shareId)
 
-    if (!result.success || !result.data) {
-        return {
-            title: 'Whiteboard Not Found',
-        }
-    }
-
+  if (!result.success || !result.data) {
     return {
-        title: `${result.data.name} - Shared Whiteboard`,
-        description: `View ${result.data.name} - a shared whiteboard`,
+      title: 'Whiteboard Not Found',
     }
+  }
+
+  return {
+    title: `${result.data.name} - Shared Whiteboard`,
+    description: `View ${result.data.name} - a shared whiteboard`,
+  }
 }

--- a/src/components/whiteboard/comment-overlay.tsx
+++ b/src/components/whiteboard/comment-overlay.tsx
@@ -1,0 +1,378 @@
+// src/components/whiteboard/comment-overlay.tsx
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { CommentPin, CommentData } from './comment-pin'
+import { createComment, getWhiteboardComments } from '@/lib/actions/comment'
+
+interface CommentOverlayProps {
+  whiteboardId: string
+  isOwner: boolean
+  isReadOnly?: boolean
+  initialComments?: CommentData[]
+}
+
+interface NewCommentForm {
+  x: number
+  y: number
+  canvasX: number
+  canvasY: number
+  text: string
+  isVisible: boolean
+}
+
+export function CommentOverlay({ 
+  whiteboardId, 
+  isOwner, 
+  isReadOnly = false,
+  initialComments = []
+}: CommentOverlayProps) {
+  const [comments, setComments] = useState<CommentData[]>(initialComments)
+  const [newComment, setNewComment] = useState<NewCommentForm>({
+    x: 0,
+    y: 0,
+    canvasX: 0,
+    canvasY: 0,
+    text: '',
+    isVisible: false
+  })
+  const [isCommentMode, setIsCommentMode] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [viewportState, setViewportState] = useState({ x: 0, y: 0, z: 1 })
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  // Load comments on mount
+  useEffect(() => {
+    if (isOwner) {
+      loadComments()
+    }
+  }, [whiteboardId, isOwner])
+
+  // Track viewport changes by observing TLDraw container
+  useEffect(() => {
+    const trackViewport = () => {
+      // Try to find the TLDraw canvas element
+      const canvas = document.querySelector('.tl-canvas')
+      if (canvas) {
+        // Get transform from the canvas
+        const transform = window.getComputedStyle(canvas).transform
+        if (transform && transform !== 'none') {
+          // Parse matrix transform to get x, y, z values
+          const values = transform.split('(')[1]?.split(')')[0]?.split(',')
+          if (values && values.length >= 6) {
+            const scaleX = parseFloat(values[0])
+            const translateX = parseFloat(values[4])
+            const translateY = parseFloat(values[5])
+            
+            setViewportState({
+              x: translateX,
+              y: translateY,
+              z: scaleX
+            })
+          }
+        }
+      }
+    }
+
+    // Set up mutation observer to track changes
+    const observer = new MutationObserver(() => {
+      trackViewport()
+    })
+
+    // Start observing
+    const canvas = document.querySelector('.tl-canvas')
+    if (canvas) {
+      observer.observe(canvas, {
+        attributes: true,
+        attributeFilter: ['style', 'transform']
+      })
+    }
+
+    // Also track on scroll/resize
+    const handleViewportChange = () => trackViewport()
+    window.addEventListener('scroll', handleViewportChange)
+    window.addEventListener('resize', handleViewportChange)
+
+    // Initial tracking
+    trackViewport()
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('scroll', handleViewportChange)
+      window.removeEventListener('resize', handleViewportChange)
+    }
+  }, [])
+
+  const loadComments = async () => {
+    try {
+      const result = await getWhiteboardComments(whiteboardId, true)
+      if (result.success && result.data) {
+        setComments(result.data)
+      }
+    } catch (error) {
+      console.error('Failed to load comments:', error)
+    }
+  }
+
+  // Handle clicks for comment mode - simplified approach
+  const handleOverlayClick = (event: React.MouseEvent) => {
+    if (!isCommentMode || isReadOnly || !isOwner) return
+    
+    // Don't create comment if clicking on the comment form itself
+    const target = event.target as Element
+    if (target.closest('.comment-form') || target.closest('.comment-pin')) {
+      return
+    }
+
+    // Stop event propagation
+    event.preventDefault()
+    event.stopPropagation()
+    
+    // Get the canvas container for positioning
+    const tlEditor = document.querySelector('.tl-editor')
+    const canvasContainer = document.querySelector('.tl-canvas') || tlEditor
+    
+    if (!canvasContainer) return
+    
+    const rect = canvasContainer.getBoundingClientRect()
+    
+    // Calculate positions relative to canvas
+    const screenX = event.clientX - rect.left
+    const screenY = event.clientY - rect.top
+    const canvasX = (screenX - viewportState.x) / viewportState.z
+    const canvasY = (screenY - viewportState.y) / viewportState.z
+
+    // Show comment form at click position
+    setNewComment({
+      x: event.clientX, // Global screen position for form
+      y: event.clientY,
+      canvasX,
+      canvasY,
+      text: '',
+      isVisible: true
+    })
+  }
+
+  // Handle ESC key to exit comment mode
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isCommentMode) {
+        setIsCommentMode(false)
+        setNewComment({ x: 0, y: 0, canvasX: 0, canvasY: 0, text: '', isVisible: false })
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isCommentMode])
+
+  const handleSubmitComment = async () => {
+    if (!newComment.text.trim() || isSubmitting) return
+
+    setIsSubmitting(true)
+    try {
+      const result = await createComment({
+        whiteboardId,
+        text: newComment.text.trim(),
+        x: newComment.canvasX,
+        y: newComment.canvasY,
+      })
+
+      if (result.success && result.data) {
+        setComments(prev => [result.data, ...prev])
+        setNewComment({ x: 0, y: 0, canvasX: 0, canvasY: 0, text: '', isVisible: false })
+        // Exit comment mode after adding comment
+        setIsCommentMode(false)
+      }
+    } catch (error) {
+      console.error('Failed to create comment:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleCancelComment = () => {
+    setNewComment({ x: 0, y: 0, canvasX: 0, canvasY: 0, text: '', isVisible: false })
+    // Exit comment mode when cancelling
+    setIsCommentMode(false)
+  }
+
+  const handleUpdateComment = (commentId: string, data: { text?: string; resolved?: boolean }) => {
+    setComments(prev => 
+      prev.map(comment => 
+        comment.id === commentId 
+          ? { ...comment, ...data, updatedAt: new Date().toISOString() }
+          : comment
+      )
+    )
+  }
+
+  const handleDeleteComment = (commentId: string) => {
+    setComments(prev => prev.filter(comment => comment.id !== commentId))
+  }
+
+  // Convert canvas coordinates to screen coordinates for display
+  const getScreenCoordinates = (canvasX: number, canvasY: number) => {
+    return {
+      x: canvasX * viewportState.z + viewportState.x,
+      y: canvasY * viewportState.z + viewportState.y
+    }
+  }
+
+  return (
+    <>
+      {/* Comment Mode Toggle Button */}
+      {isOwner && !isReadOnly && (
+        <div className="fixed bottom-6 right-6 z-40">
+          <button
+            onClick={() => setIsCommentMode(!isCommentMode)}
+            className={`w-12 h-12 rounded-full shadow-lg flex items-center justify-center transition-colors ${
+              isCommentMode 
+                ? 'bg-blue-600 text-white' 
+                : 'bg-white text-gray-700 hover:bg-gray-50'
+            }`}
+            title={isCommentMode ? 'Exit comment mode' : 'Add comments'}
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+          </button>
+          
+          {isCommentMode && (
+            <div className="absolute bottom-14 right-0 bg-blue-600 text-white text-xs px-2 py-1 rounded whitespace-nowrap">
+              Click on canvas to add comment
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* REMOVED: The blocking overlay div that was causing the issue */}
+
+      {/* Comment Pins - Fixed pointer events */}
+      <div className="absolute inset-0 pointer-events-none z-20">
+        <div className="relative w-full h-full">
+          {comments.map((comment) => {
+            const screenCoords = getScreenCoordinates(comment.x, comment.y)
+            return (
+              <div 
+                key={comment.id}
+                className="absolute pointer-events-auto"
+                style={{
+                  left: screenCoords.x,
+                  top: screenCoords.y,
+                  transform: 'translate(-50%, -50%)'
+                }}
+              >
+                <CommentPin
+                  comment={{
+                    ...comment,
+                    x: 0, // Relative to parent div
+                    y: 0
+                  }}
+                  isOwner={isOwner}
+                  isReadOnly={isReadOnly}
+                  onUpdate={handleUpdateComment}
+                  onDelete={handleDeleteComment}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* New Comment Form */}
+      {newComment.isVisible && (
+        <div
+          className="comment-form fixed z-50 bg-white border border-gray-300 rounded-lg shadow-lg p-3 w-72"
+          style={{
+            left: Math.min(newComment.x + 20, window.innerWidth - 300),
+            top: Math.min(newComment.y + 20, window.innerHeight - 150),
+          }}
+          onClick={(e) => e.stopPropagation()} // Prevent clicks on form from bubbling
+        >
+          <div className="mb-2">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Add Comment
+            </label>
+            <textarea
+              value={newComment.text}
+              onChange={(e) => setNewComment(prev => ({ ...prev, text: e.target.value }))}
+              className="w-full p-2 border border-gray-300 rounded text-sm resize-none"
+              rows={3}
+              placeholder="Type your comment here..."
+              disabled={isSubmitting}
+              autoFocus
+              onClick={(e) => e.stopPropagation()} // Prevent textarea clicks from bubbling
+            />
+          </div>
+          
+          <div className="flex justify-end space-x-2">
+            <button
+              onClick={handleCancelComment}
+              disabled={isSubmitting}
+              className="px-3 py-1 text-sm text-gray-600 hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmitComment}
+              disabled={!newComment.text.trim() || isSubmitting}
+              className="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50"
+            >
+              {isSubmitting ? 'Adding...' : 'Add Comment'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Comments Summary */}
+      {comments.length > 0 && (
+        <div className="fixed top-4 left-4 z-40 bg-white rounded-lg shadow-lg p-2 text-sm">
+          <div className="flex items-center space-x-2">
+            <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+            <span>{comments.filter(c => !c.resolved).length} open</span>
+            <span className="text-gray-400">•</span>
+            <span className="text-green-600">{comments.filter(c => c.resolved).length} resolved</span>
+          </div>
+        </div>
+      )}
+
+      {/* Visual indicator and interaction blocker when in comment mode */}
+      {isCommentMode && (
+        <>
+          {/* Interaction blocker with click handler */}
+          <div 
+            className="absolute inset-0 z-30 cursor-crosshair"
+            style={{ 
+              background: 'rgba(59, 130, 246, 0.05)',
+              pointerEvents: 'auto'
+            }}
+            onClick={handleOverlayClick}
+            onMouseDown={(e) => e.stopPropagation()}
+            onMouseUp={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+          />
+          
+          {/* Visual border indicator */}
+          <div 
+            className="absolute inset-0 pointer-events-none z-31"
+            style={{
+              border: '2px dashed rgba(59, 130, 246, 0.3)',
+              borderRadius: '8px'
+            }}
+          />
+          
+          {/* Instructions overlay */}
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-32 pointer-events-none">
+            <div className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg text-sm font-medium">
+              Click anywhere to add a comment
+              <div className="text-xs mt-1 opacity-80">Press ESC to exit comment mode</div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/components/whiteboard/comment-pin.tsx
+++ b/src/components/whiteboard/comment-pin.tsx
@@ -1,0 +1,257 @@
+// src/components/whiteboard/comment-pin.tsx
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { updateComment, deleteComment } from '@/lib/actions/comment'
+import { format, parseISO } from "date-fns";
+
+export interface CommentData {
+    id: string
+    text: string
+    userName: string
+    userAvatar?: string | null
+    x: number
+    y: number
+    resolved: boolean
+    createdAt: string
+    updatedAt: string
+}
+
+interface CommentPinProps {
+    comment: CommentData
+    isOwner: boolean
+    isReadOnly?: boolean
+    onUpdate?: (commentId: string, data: { text?: string; resolved?: boolean }) => void
+    onDelete?: (commentId: string) => void
+}
+
+export function CommentPin({
+    comment,
+    isOwner,
+    isReadOnly = false,
+    onUpdate,
+    onDelete
+}: CommentPinProps) {
+    const [isOpen, setIsOpen] = useState(false)
+    const [isEditing, setIsEditing] = useState(false)
+    const [editText, setEditText] = useState(comment.text)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const tooltipRef = useRef<HTMLDivElement>(null)
+    const pinRef = useRef<HTMLDivElement>(null)
+
+    // Close tooltip when clicking outside
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (
+                tooltipRef.current &&
+                !tooltipRef.current.contains(event.target as Node) &&
+                pinRef.current &&
+                !pinRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false)
+                setIsEditing(false)
+                setEditText(comment.text)
+            }
+        }
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside)
+            return () => document.removeEventListener('mousedown', handleClickOutside)
+        }
+    }, [isOpen, comment.text])
+
+    const handleSave = async () => {
+        if (!editText.trim() || isSubmitting) return
+
+        setIsSubmitting(true)
+        try {
+            const result = await updateComment(comment.id, { text: editText.trim() })
+            if (result.success) {
+                onUpdate?.(comment.id, { text: editText.trim() })
+                setIsEditing(false)
+            }
+        } catch (error) {
+            console.error('Failed to update comment:', error)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const handleResolve = async () => {
+        if (isSubmitting) return
+
+        setIsSubmitting(true)
+        try {
+            const result = await updateComment(comment.id, { resolved: !comment.resolved })
+            if (result.success) {
+                onUpdate?.(comment.id, { resolved: !comment.resolved })
+            }
+        } catch (error) {
+            console.error('Failed to resolve comment:', error)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const handleDelete = async () => {
+        if (!confirm('Are you sure you want to delete this comment?') || isSubmitting) return
+
+        setIsSubmitting(true)
+        try {
+            const result = await deleteComment(comment.id)
+            if (result.success) {
+                onDelete?.(comment.id)
+            }
+        } catch (error) {
+            console.error('Failed to delete comment:', error)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const formatDate = (dateString: string) => {
+        const date = parseISO(dateString);
+        return format(date, "MMMM d, yyyy h:mm a");
+    }
+    return (
+        <>
+            {/* Comment Pin */}
+            <div
+                ref={pinRef}
+                className={`absolute z-10 cursor-pointer transform -translate-x-1/2 -translate-y-1/2 ${comment.resolved ? 'opacity-50' : ''
+                    }`}
+                style={{ left: comment.x, top: comment.y }}
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                <div className={`w-10 h-10 rounded-full border-2 border-white shadow-lg flex items-center justify-center text-white text-xs font-bold ${comment.resolved ? 'bg-green-500' : 'bg-blue-500'
+                    } hover:scale-110 transition-transform`}>
+                    {comment.resolved ? '✓' : '💬'}
+                </div>
+
+                {/* Pin number indicator */}
+                <div className="absolute -top-1 -right-1 w-6 h-6 bg-red-500 rounded-full border border-white flex items-center justify-center text-white text-xs font-bold">
+                    {comment.id.slice(-2)}
+                </div>
+            </div>
+
+            {/* Comment Tooltip */}
+            {isOpen && (
+                <div
+                    ref={tooltipRef}
+                    className="fixed z-50 bg-white border border-gray-300 rounded-lg shadow-lg p-3 max-w-sm"
+                    style={{
+                        left: Math.min(comment.x + 20, window.innerWidth - 300),
+                        top: Math.min(comment.y + 20, window.innerHeight - 200),
+                    }}
+                >
+                    {/* Header */}
+                    <div className="flex items-start justify-between mb-2">
+                        <div className="flex items-center space-x-2">
+                            {comment.userAvatar ? (
+                                <img
+                                    src={comment.userAvatar}
+                                    alt={comment.userName}
+                                    className="w-6 h-6 rounded-full"
+                                />
+                            ) : (
+                                <div className="w-6 h-6 bg-gray-400 rounded-full flex items-center justify-center text-white text-xs">
+                                    {comment.userName.charAt(0).toUpperCase()}
+                                </div>
+                            )}
+                            <div>
+                                <div className="font-medium text-sm">{comment.userName}</div>
+                                <div className="text-xs text-gray-500">{formatDate(comment.createdAt)}</div>
+                            </div>
+                        </div>
+
+                        {/* Status indicator */}
+                        <div className={`px-2 py-1 rounded-full text-xs ${comment.resolved
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-blue-100 text-blue-800'
+                            }`}>
+                            {comment.resolved ? 'Resolved' : 'Open'}
+                        </div>
+                    </div>
+
+                    {/* Comment Content */}
+                    <div className="mb-3">
+                        {isEditing ? (
+                            <div className="space-y-2">
+                                <textarea
+                                    value={editText}
+                                    onChange={(e) => setEditText(e.target.value)}
+                                    className="w-full p-2 border border-gray-300 rounded text-sm resize-none"
+                                    rows={3}
+                                    placeholder="Edit your comment..."
+                                    disabled={isSubmitting}
+                                />
+                                <div className="flex justify-end space-x-2">
+                                    <button
+                                        onClick={() => {
+                                            setIsEditing(false)
+                                            setEditText(comment.text)
+                                        }}
+                                        disabled={isSubmitting}
+                                        className="cursor-pointer px-2 py-1 text-xs text-gray-600 hover:text-gray-800"
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        onClick={handleSave}
+                                        disabled={!editText.trim() || isSubmitting}
+                                        className="cursor-pointer px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:opacity-50"
+                                    >
+                                        {isSubmitting ? 'Saving...' : 'Save'}
+                                    </button>
+                                </div>
+                            </div>
+                        ) : (
+                            <p className="text-sm text-gray-800 whitespace-pre-wrap">{comment.text}</p>
+                        )}
+                    </div>
+
+                    {/* Actions */}
+                    {isOwner && !isReadOnly && (
+                        <div className="flex justify-between items-center pt-2 border-t border-gray-200">
+                            <div className="flex space-x-1">
+                                <button
+                                    onClick={() => setIsEditing(!isEditing)}
+                                    disabled={isSubmitting}
+                                    className="cursor-pointer px-2 py-1 text-xs text-gray-600 hover:text-gray-800"
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    onClick={handleDelete}
+                                    disabled={isSubmitting}
+                                    className="cursor-pointer px-2 py-1 text-xs text-red-600 hover:text-red-800"
+                                >
+                                    Delete
+                                </button>
+                            </div>
+
+                            <button
+                                onClick={handleResolve}
+                                disabled={isSubmitting}
+                                className={`cursor-pointer px-2 py-1 text-xs rounded ${comment.resolved
+                                        ? 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
+                                        : 'bg-green-100 text-green-800 hover:bg-green-200'
+                                    }`}
+                            >
+                                {isSubmitting ? '...' : comment.resolved ? 'Reopen' : 'Resolve'}
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Close button */}
+                    <button
+                        onClick={() => setIsOpen(false)}
+                        className="cursor-pointer absolute -top-2 -right-2 w-6 h-6 bg-gray-500 text-white rounded-full hover:bg-gray-600 flex items-center justify-center text-xs"
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
+        </>
+    )
+}

--- a/src/components/whiteboard/shared-whiteboard-viewer.tsx
+++ b/src/components/whiteboard/shared-whiteboard-viewer.tsx
@@ -1,0 +1,114 @@
+// src/components/whiteboard/shared-whiteboard-viewer.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Tldraw, createTLStore, defaultShapeUtils, defaultTools, useEditor } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+interface SharedWhiteboardData {
+  id: string
+  name: string
+  content: any
+  createdAt: string
+  updatedAt: string
+}
+
+interface SharedWhiteboardViewerProps {
+  whiteboard: SharedWhiteboardData
+}
+
+// Custom component to make the editor read-only
+function ReadOnlyWrapper() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    // Make the editor read-only by disabling user interactions
+    editor.updateInstanceState({ isReadonly: true })
+    
+    // Disable all tools except select and hand
+    const currentTool = editor.getCurrentTool()
+    if (currentTool?.id !== 'select' && currentTool?.id !== 'hand') {
+      editor.setCurrentTool('select')
+    }
+  }, [editor])
+
+  return null
+}
+
+export function SharedWhiteboardViewer({ whiteboard }: SharedWhiteboardViewerProps) {
+  const [store] = useState(() => createTLStore({ 
+    shapeUtils: defaultShapeUtils, 
+  }))
+
+  // Load initial content
+  useEffect(() => {
+    if (whiteboard.content) {
+      store.loadSnapshot(whiteboard.content)
+    }
+  }, [store, whiteboard.content])
+
+  const formattedDate = new Date(whiteboard.updatedAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+  return (
+    <>
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="flex items-center space-x-2">
+              <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+              </svg>
+              <h1 className="text-lg font-semibold text-gray-900">{whiteboard.name}</h1>
+            </div>
+            
+            <div className="flex items-center space-x-2 text-sm">
+              <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-medium">
+                Shared
+              </span>
+              <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs font-medium">
+                Read-Only
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-4 text-sm text-gray-500">
+            <span>Last updated: {formattedDate}</span>
+          </div>
+        </div>
+        
+        {/* Info banner */}
+        <div className="mt-3 bg-blue-50 border border-blue-200 rounded-lg p-3">
+          <p className="text-sm text-blue-800">
+            👀 You're viewing a shared whiteboard in read-only mode. 
+            You can view and zoom around, but cannot make changes.
+          </p>
+        </div>
+      </div>
+
+      {/* TLDraw Viewer - Read-only mode */}
+      <div className="flex-1">
+        <Tldraw 
+          store={store}
+          hideUi={true}
+          components={{
+            ActionsMenu: null,
+            ContextMenu: null,
+            QuickActions: null,
+            HelpMenu: null,
+            ZoomMenu: null,
+            MainMenu: null,
+          }}
+        >
+          <ReadOnlyWrapper />
+        </Tldraw>
+      </div>
+    </>
+  )
+}

--- a/src/components/whiteboard/sharing-modal.tsx
+++ b/src/components/whiteboard/sharing-modal.tsx
@@ -1,0 +1,153 @@
+// src/components/whiteboard/sharing-modal.tsx
+'use client'
+
+import { useState, useTransition } from 'react'
+import { generateShareLink, disableSharing } from '@/lib/actions/sharing'
+
+interface SharingModalProps {
+    whiteboardId: string
+    whiteboardName: string
+    currentShareId: string | null
+    isPubliclyShared: boolean
+    isOpen: boolean
+    onClose: () => void
+}
+
+export function SharingModal({
+    whiteboardId,
+    whiteboardName,
+    currentShareId,
+    isPubliclyShared,
+    isOpen,
+    onClose,
+}: SharingModalProps) {
+    const [shareUrl, setShareUrl] = useState(
+        currentShareId && isPubliclyShared
+            ? `${window.location.origin}/shared/${currentShareId}`
+            : null
+    )
+    const [isShared, setIsShared] = useState(isPubliclyShared)
+    const [copySuccess, setCopySuccess] = useState(false)
+    const [isPending, startTransition] = useTransition()
+
+    if (!isOpen) return null
+
+    const handleGenerateLink = () => {
+        startTransition(async () => {
+            const result = await generateShareLink(whiteboardId)
+            if (result.success && result.data) {
+                setShareUrl(result.data.shareUrl)
+                setIsShared(true)
+            } else {
+                alert(result.error || 'Failed to generate share link')
+            }
+        })
+    }
+
+    const handleDisableSharing = () => {
+        startTransition(async () => {
+            const result = await disableSharing(whiteboardId)
+            if (result.success) {
+                setIsShared(false)
+                setShareUrl(null)
+            } else {
+                alert(result.error || 'Failed to disable sharing')
+            }
+        })
+    }
+
+    const handleCopyLink = async () => {
+        if (!shareUrl) return
+
+        try {
+            await navigator.clipboard.writeText(shareUrl)
+            setCopySuccess(true)
+            setTimeout(() => setCopySuccess(false), 2000)
+        } catch (error) {
+            console.error('Failed to copy link:', error)
+        }
+    }
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
+                <div className="flex justify-between items-center mb-4">
+                    <h2 className="text-xl font-semibold">Share Whiteboard</h2>
+                    <button
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-600"
+                    >
+                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div className="mb-4">
+                    <h3 className="font-medium text-gray-900 mb-2">{whiteboardName}</h3>
+                    <p className="text-sm text-gray-600">
+                        Share this whiteboard with others. They will be able to view it in read-only mode.
+                    </p>
+                </div>
+
+                {!isShared ? (
+                    <div className="space-y-4">
+                        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                            <p className="text-sm text-blue-800">
+                                Generate a public link to share this whiteboard. Anyone with the link will be able to view it.
+                            </p>
+                        </div>
+                        <button
+                            onClick={handleGenerateLink}
+                            disabled={isPending}
+                            className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isPending ? 'Generating...' : 'Generate Share Link'}
+                        </button>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium text-gray-700">Share Link</label>
+                            <div className="flex items-center space-x-2">
+                                <input
+                                    type="text"
+                                    value={shareUrl || ''}
+                                    readOnly
+                                    className="flex-1 px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-sm"
+                                />
+                                <button
+                                    onClick={handleCopyLink}
+                                    className="px-3 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm"
+                                >
+                                    {copySuccess ? 'Copied!' : 'Copy'}
+                                </button>
+                            </div>
+                        </div>
+
+                        <div className="bg-green-50 border border-green-200 rounded-lg p-3">
+                            <p className="text-sm text-green-800">
+                                🎉 Your whiteboard is now publicly shareable! Anyone with this link can view it.
+                            </p>
+                        </div>
+
+                        <div className="flex space-x-3">
+                            <button
+                                onClick={handleDisableSharing}
+                                disabled={isPending}
+                                className="flex-1 bg-red-600 text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {isPending ? 'Disabling...' : 'Disable Sharing'}
+                            </button>
+                            <button
+                                onClick={onClose}
+                                className="flex-1 bg-gray-200 text-gray-800 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors"
+                            >
+                                Close
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/components/whiteboard/sharing-modal.tsx
+++ b/src/components/whiteboard/sharing-modal.tsx
@@ -1,7 +1,7 @@
 // src/components/whiteboard/sharing-modal.tsx
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useEffect, useState, useTransition } from 'react'
 import { generateShareLink, disableSharing } from '@/lib/actions/sharing'
 
 interface SharingModalProps {
@@ -21,14 +21,16 @@ export function SharingModal({
     isOpen,
     onClose,
 }: SharingModalProps) {
-    const [shareUrl, setShareUrl] = useState(
-        currentShareId && isPubliclyShared
-            ? `${window.location.origin}/shared/${currentShareId}`
-            : null
-    )
+    const [shareUrl, setShareUrl] = useState<string | null>(null)
     const [isShared, setIsShared] = useState(isPubliclyShared)
     const [copySuccess, setCopySuccess] = useState(false)
     const [isPending, startTransition] = useTransition()
+
+    useEffect(() => {
+        if (currentShareId && isPubliclyShared) {
+            setShareUrl(`${window.location.origin}/shared/${currentShareId}`)
+        }
+    }, [currentShareId, isPubliclyShared])
 
     if (!isOpen) return null
 

--- a/src/components/whiteboard/whiteboard-editor.tsx
+++ b/src/components/whiteboard/whiteboard-editor.tsx
@@ -6,6 +6,7 @@ import { Tldraw, createTLStore, defaultShapeUtils, defaultTools } from 'tldraw'
 import { updateWhiteboard } from '@/lib/actions/whiteboard'
 import { Whiteboard, WhiteboardStatus } from '@/types/whiteboard'
 import { useRouter } from 'next/navigation'
+import { SharingModal } from './sharing-modal'
 import 'tldraw/tldraw.css'
 
 interface WhiteboardEditorProps {
@@ -24,6 +25,7 @@ export function WhiteboardEditor({ whiteboard }: WhiteboardEditorProps) {
   const [currentStatus, setCurrentStatus] = useState<WhiteboardStatus>(whiteboard.status)
   const [currentName, setCurrentName] = useState(whiteboard.name)
   const [isEditingName, setIsEditingName] = useState(false)
+  const [showSharingModal, setShowSharingModal] = useState(false)
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
 
@@ -115,6 +117,14 @@ export function WhiteboardEditor({ whiteboard }: WhiteboardEditorProps) {
     }
   }
 
+  const handleShare = () => {
+    if (currentStatus !== 'PUBLISHED') {
+      alert('Only published whiteboards can be shared. Please publish this whiteboard first.')
+      return
+    }
+    setShowSharingModal(true)
+  }
+
   return (
     <>
       {/* Header */}
@@ -173,6 +183,16 @@ export function WhiteboardEditor({ whiteboard }: WhiteboardEditorProps) {
               <option value="DRAFT">Draft</option>
               <option value="PUBLISHED">Published</option>
             </select>
+
+            {/* Share indicator */}
+            {whiteboard.isPubliclyShared && currentStatus === 'PUBLISHED' && (
+              <div className="flex items-center space-x-1 text-green-600 text-sm">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
+                </svg>
+                <span>Shared</span>
+              </div>
+            )}
           </div>
         </div>
 
@@ -193,6 +213,20 @@ export function WhiteboardEditor({ whiteboard }: WhiteboardEditorProps) {
           </div>
 
           <button
+            onClick={handleShare}
+            disabled={currentStatus !== 'PUBLISHED'}
+            className="bg-green-600 text-white px-3 py-1 rounded text-sm font-medium hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title={currentStatus !== 'PUBLISHED' ? 'Publish the whiteboard first to enable sharing' : 'Share this whiteboard'}
+          >
+            <div className="flex items-center space-x-1">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
+              </svg>
+              <span>Share</span>
+            </div>
+          </button>
+
+          <button
             onClick={handleManualSave}
             disabled={isSaving || !hasUnsavedChanges}
             className="bg-blue-600 text-white px-3 py-1 rounded text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -206,6 +240,16 @@ export function WhiteboardEditor({ whiteboard }: WhiteboardEditorProps) {
       <div className="flex-1">
         <Tldraw store={store} />
       </div>
+
+      {/* Sharing Modal */}
+      <SharingModal
+        whiteboardId={whiteboard.id}
+        whiteboardName={currentName}
+        currentShareId={whiteboard.shareId ?? null}
+        isPubliclyShared={whiteboard.isPubliclyShared || false}
+        isOpen={showSharingModal}
+        onClose={() => setShowSharingModal(false)}
+      />
     </>
   )
 }

--- a/src/lib/actions/comment.ts
+++ b/src/lib/actions/comment.ts
@@ -1,0 +1,221 @@
+// src/lib/actions/comment.ts
+'use server'
+
+import { auth, currentUser } from '@clerk/nextjs/server'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+
+export interface CreateCommentData {
+    whiteboardId: string
+    text: string
+    x: number
+    y: number
+}
+
+export interface UpdateCommentData {
+    text?: string
+    resolved?: boolean
+}
+
+export async function createComment(data: CreateCommentData) {
+    const { userId } = await auth()
+    const user = await currentUser()
+
+    if (!userId || !user) {
+        throw new Error('Unauthorized')
+    }
+
+    try {
+        // Verify user has access to the whiteboard
+        const whiteboard = await prisma.whiteboard.findFirst({
+            where: {
+                id: data.whiteboardId,
+                userId // Only owner can add comments for now
+            },
+        })
+
+        if (!whiteboard) {
+            return { success: false, error: 'Whiteboard not found or unauthorized' }
+        }
+
+        const comment = await prisma.comment.create({
+            data: {
+                whiteboardId: data.whiteboardId,
+                userId,
+                userName: user.fullName || user.emailAddresses[0]?.emailAddress || 'Anonymous',
+                userEmail: user.emailAddresses[0]?.emailAddress,
+                userAvatar: user.imageUrl,
+                text: data.text,
+                x: data.x,
+                y: data.y,
+            },
+        })
+
+        revalidatePath(`/whiteboards/${data.whiteboardId}`)
+
+        return {
+            success: true,
+            data: {
+                ...comment,
+                createdAt: comment.createdAt.toISOString(),
+                updatedAt: comment.updatedAt.toISOString(),
+            },
+        }
+    } catch (error) {
+        console.error('Create comment error:', error)
+        return { success: false, error: 'Failed to create comment' }
+    }
+}
+
+export async function updateComment(commentId: string, data: UpdateCommentData) {
+    const { userId } = await auth()
+
+    if (!userId) {
+        throw new Error('Unauthorized')
+    }
+
+    try {
+        // Verify ownership of the comment
+        const existingComment = await prisma.comment.findFirst({
+            where: { id: commentId, userId },
+        })
+
+        if (!existingComment) {
+            return { success: false, error: 'Comment not found or unauthorized' }
+        }
+
+        const comment = await prisma.comment.update({
+            where: { id: commentId },
+            data: {
+                ...(data.text !== undefined && { text: data.text }),
+                ...(data.resolved !== undefined && { resolved: data.resolved }),
+                updatedAt: new Date(),
+            },
+        })
+
+        revalidatePath(`/whiteboards/${existingComment.whiteboardId}`)
+
+        return {
+            success: true,
+            data: {
+                ...comment,
+                createdAt: comment.createdAt.toISOString(),
+                updatedAt: comment.updatedAt.toISOString(),
+            },
+        }
+    } catch (error) {
+        console.error('Update comment error:', error)
+        return { success: false, error: 'Failed to update comment' }
+    }
+}
+
+export async function deleteComment(commentId: string) {
+    const { userId } = await auth()
+
+    if (!userId) {
+        throw new Error('Unauthorized')
+    }
+
+    try {
+        // Verify ownership of the comment
+        const existingComment = await prisma.comment.findFirst({
+            where: { id: commentId, userId },
+        })
+
+        if (!existingComment) {
+            return { success: false, error: 'Comment not found or unauthorized' }
+        }
+
+        await prisma.comment.delete({
+            where: { id: commentId },
+        })
+
+        revalidatePath(`/whiteboards/${existingComment.whiteboardId}`)
+
+        return { success: true }
+    } catch (error) {
+        console.error('Delete comment error:', error)
+        return { success: false, error: 'Failed to delete comment' }
+    }
+}
+
+export async function getWhiteboardComments(whiteboardId: string, includeResolved: boolean = true) {
+    const { userId } = await auth()
+
+    if (!userId) {
+        throw new Error('Unauthorized')
+    }
+
+    try {
+        // Verify user has access to the whiteboard
+        const whiteboard = await prisma.whiteboard.findFirst({
+            where: {
+                id: whiteboardId,
+                userId
+            },
+        })
+
+        if (!whiteboard) {
+            return { success: false, error: 'Whiteboard not found or unauthorized' }
+        }
+
+        const comments = await prisma.comment.findMany({
+            where: {
+                whiteboardId,
+                ...(includeResolved ? {} : { resolved: false }),
+            },
+            orderBy: {
+                createdAt: 'desc',
+            },
+        })
+
+        const serializedComments = comments.map(comment => ({
+            ...comment,
+            createdAt: comment.createdAt.toISOString(),
+            updatedAt: comment.updatedAt.toISOString(),
+        }))
+
+        return { success: true, data: serializedComments }
+    } catch (error) {
+        console.error('Get comments error:', error)
+        return { success: false, error: 'Failed to fetch comments' }
+    }
+}
+
+// For shared whiteboards - read-only access to comments
+export async function getSharedWhiteboardComments(shareId: string) {
+    try {
+        const whiteboard = await prisma.whiteboard.findFirst({
+            where: {
+                shareId,
+                isPubliclyShared: true,
+                status: 'PUBLISHED'
+            },
+        })
+
+        if (!whiteboard) {
+            return { success: false, error: 'Shared whiteboard not found' }
+        }
+
+        const comments = await prisma.comment.findMany({
+            where: {
+                whiteboardId: whiteboard.id,
+                resolved: false, // Only show unresolved comments in shared view
+            },
+            orderBy: {
+                createdAt: 'desc',
+            },
+        })
+
+        const serializedComments = comments.map(comment => ({
+            ...comment,
+            createdAt: comment.createdAt.toISOString(),
+            updatedAt: comment.updatedAt.toISOString(),
+        }))
+
+        return { success: true, data: serializedComments }
+    } catch (error) {
+        console.error('Get shared comments error:', error)
+        return { success: false, error: 'Failed to fetch comments' }
+    }
+}

--- a/src/lib/actions/sharing.ts
+++ b/src/lib/actions/sharing.ts
@@ -1,0 +1,123 @@
+// src/lib/actions/sharing.ts
+'use server'
+
+import { auth } from '@clerk/nextjs/server'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+import { nanoid } from 'nanoid'
+
+export async function generateShareLink(whiteboardId: string) {
+  const { userId } = await auth()
+
+  if (!userId) {
+    throw new Error('Unauthorized')
+  }
+
+  try {
+    // Verify ownership and check if whiteboard is published
+    const whiteboard = await prisma.whiteboard.findFirst({
+      where: { id: whiteboardId, userId },
+    })
+
+    if (!whiteboard) {
+      return { success: false, error: 'Whiteboard not found or unauthorized' }
+    }
+
+    if (whiteboard.status !== 'PUBLISHED') {
+      return { success: false, error: 'Only published whiteboards can be shared' }
+    }
+
+    // Generate or retrieve share ID
+    let shareId = whiteboard.shareId
+    if (!shareId) {
+      shareId = nanoid(12) // Generate a 12-character unique ID
+    }
+
+    const updatedWhiteboard = await prisma.whiteboard.update({
+      where: { id: whiteboardId },
+      data: {
+        shareId,
+        isPubliclyShared: true,
+      },
+    })
+
+    revalidatePath(`/whiteboards/${whiteboardId}`)
+
+    return {
+      success: true,
+      data: {
+        shareId: updatedWhiteboard.shareId,
+        shareUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/shared/${updatedWhiteboard.shareId}`,
+      },
+    }
+  } catch (error) {
+    console.error('Generate share link error:', error)
+    return { success: false, error: 'Failed to generate share link' }
+  }
+}
+
+export async function disableSharing(whiteboardId: string) {
+  const { userId } = await auth()
+
+  if (!userId) {
+    throw new Error('Unauthorized')
+  }
+
+  try {
+    const whiteboard = await prisma.whiteboard.findFirst({
+      where: { id: whiteboardId, userId },
+    })
+
+    if (!whiteboard) {
+      return { success: false, error: 'Whiteboard not found or unauthorized' }
+    }
+
+    await prisma.whiteboard.update({
+      where: { id: whiteboardId },
+      data: {
+        isPubliclyShared: false,
+      },
+    })
+
+    revalidatePath(`/whiteboards/${whiteboardId}`)
+    return { success: true }
+  } catch (error) {
+    console.error('Disable sharing error:', error)
+    return { success: false, error: 'Failed to disable sharing' }
+  }
+}
+
+export async function getSharedWhiteboard(shareId: string) {
+  try {
+    const whiteboard = await prisma.whiteboard.findFirst({
+      where: { 
+        shareId,
+        isPubliclyShared: true,
+        status: 'PUBLISHED'
+      },
+      select: {
+        id: true,
+        name: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+      }
+    })
+
+    if (!whiteboard) {
+      return { success: false, error: 'Shared whiteboard not found or no longer available' }
+    }
+
+    return {
+      success: true,
+      data: {
+        ...whiteboard,
+        createdAt: whiteboard.createdAt.toISOString(),
+        updatedAt: whiteboard.updatedAt.toISOString(),
+      },
+    }
+  } catch (error) {
+    console.error('Get shared whiteboard error:', error)
+    return { success: false, error: 'Failed to fetch shared whiteboard' }
+  }
+}

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,27 @@
+// src/types/comment.ts
+export interface Comment {
+  id: string
+  whiteboardId: string
+  userId: string
+  userName: string
+  userEmail?: string | null
+  userAvatar?: string | null
+  text: string
+  x: number
+  y: number
+  resolved: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateCommentData {
+  whiteboardId: string
+  text: string
+  x: number
+  y: number
+}
+
+export interface UpdateCommentData {
+  text?: string
+  resolved?: boolean
+}

--- a/src/types/whiteboard.ts
+++ b/src/types/whiteboard.ts
@@ -2,13 +2,15 @@
 export type WhiteboardStatus = 'DRAFT' | 'PUBLISHED';
 
 export interface Whiteboard {
-  id: string;
-  name: string;
-  status: WhiteboardStatus;
-  content: any; // TLDraw snapshot
-  userId: string;
-  createdAt: string; // Changed from Date to string for serialization
-  updatedAt: string; // Changed from Date to string for serialization
+  id: string
+  name: string
+  status: WhiteboardStatus
+  content: any // TLDraw snapshot data
+  userId: string
+  shareId?: string | null
+  isPubliclyShared?: boolean
+  createdAt: string
+  updatedAt: string
 }
 
 export interface CreateWhiteboardData {


### PR DESCRIPTION
- Added sharing modal for generating and disabling share links.
- Introduced `generateShareLink` and `disableSharing` functions in the sharing actions.
- Updated whiteboard model to include `shareId` and `isPubliclyShared` fields.
- Created `SharedWhiteboardViewer` component for displaying shared whiteboards in read-only mode.
- Integrated sharing features into the whiteboard editor.
- Added validation to ensure only published whiteboards can be shared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public sharing: generate, copy, and disable shareable whiteboard links; Share button and shared status badge in the editor.
  * Read-only viewer page for shared whiteboards with dynamic page titles/metadata.
  * In-app commenting: comment pins, overlay UI for adding/editing/resolving comments, comment counts, and read-only comment viewing on shared boards.
  * Sharing modal and integrated comment overlays in the editor.

* **Chores**
  * Added a runtime dependency to support share link generation.

* **Documentation**
  * Expanded README with full project overview, setup, and deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->